### PR TITLE
 NgoConfigのTimeoutSecondsをTimeSpanに変更する

### DIFF
--- a/Runtime/NgoClient.cs
+++ b/Runtime/NgoClient.cs
@@ -161,7 +161,7 @@ namespace Extreal.Integration.Multiplay.NGO
             {
                 await UniTask
                     .WaitUntil(() => networkManager.IsConnectedClient, cancellationToken: token)
-                    .Timeout(TimeSpan.FromSeconds(ngoConfig.TimeoutSeconds));
+                    .Timeout(ngoConfig.Timeout);
             }
             catch (TimeoutException)
             {

--- a/Runtime/NgoConfig.cs
+++ b/Runtime/NgoConfig.cs
@@ -29,23 +29,26 @@ namespace Extreal.Integration.Multiplay.NGO
         /// <summary>
         /// Uses when connection is not successful.
         /// </summary>
-        /// <value>Number of seconds to wait when connection is not successful.</value>
-        public byte TimeoutSeconds { get; internal set; }
+        /// <value>Time to wait when connection is not successful.</value>
+        public TimeSpan Timeout { get; internal set; }
 
         /// <summary>
-        /// Creates a new NgoConfig with given address, port, connectionData and timeoutSeconds.
+        /// Creates a new NgoConfig with given address, port, connectionData and timeout.
         /// </summary>
         /// <param name="address">IP Address to be used in connection.</param>
         /// <param name="port">Port to be used in connection.</param>
         /// <param name="connectionData">Connection data to be used in connection.</param>
-        /// <param name="timeoutSeconds">Number of seconds to wait when connection is not successful.</param>
+        /// <param name="timeout">
+        /// <para>Time to wait when connection is not successful.</para>
+        /// Default: 60 seconds
+        /// </param>
         /// <exception cref="ArgumentException">If the form of 'address' is invalid.</exception>
         public NgoConfig
         (
             string address = "127.0.0.1",
             ushort port = 7777,
             byte[] connectionData = null,
-            byte timeoutSeconds = 10
+            TimeSpan timeout = default
         )
         {
             if (!IPAddress.TryParse(address, out var _))
@@ -56,7 +59,7 @@ namespace Extreal.Integration.Multiplay.NGO
             Address = address;
             Port = port;
             ConnectionData = connectionData;
-            TimeoutSeconds = timeoutSeconds;
+            Timeout = timeout == default ? TimeSpan.FromSeconds(60) : timeout;
         }
     }
 }

--- a/Tests/Runtime/NgoClientTest.cs
+++ b/Tests/Runtime/NgoClientTest.cs
@@ -119,7 +119,7 @@ namespace Extreal.Integration.Multiplay.NGO.Test
         [UnityTest]
         public IEnumerator ConnectWithConnectionData() => UniTask.ToCoroutine(async () =>
         {
-            var failedNgoConfig = new NgoConfig(connectionData: new byte[] { 1, 2, 3, 4 }, timeoutSeconds: 1);
+            var failedNgoConfig = new NgoConfig(connectionData: new byte[] { 1, 2, 3, 4 }, timeout: TimeSpan.FromSeconds(1));
 
             Exception exception = null;
             try
@@ -218,7 +218,7 @@ namespace Extreal.Integration.Multiplay.NGO.Test
         [UnityTest]
         public IEnumerator ConnectWithTimeoutException() => UniTask.ToCoroutine(async () =>
         {
-            var ngoConfig = new NgoConfig(port: 7776, timeoutSeconds: 1);
+            var ngoConfig = new NgoConfig(port: 7776, timeout: TimeSpan.FromSeconds(1));
 
             Exception exception = null;
             try

--- a/Tests/Runtime/Sub/NgoServerTestSub.cs
+++ b/Tests/Runtime/Sub/NgoServerTestSub.cs
@@ -67,7 +67,7 @@ namespace Extreal.Integration.Multiplay.NGO.Test.Sub
         {
             networkManager.NetworkConfig.ConnectionApproval = true;
 
-            var failedNgoConfig = new NgoConfig(connectionData: new byte[] { 1, 2, 3, 4 }, timeoutSeconds: 1);
+            var failedNgoConfig = new NgoConfig(connectionData: new byte[] { 1, 2, 3, 4 }, timeout: TimeSpan.FromSeconds(1));
 
             Exception exception = null;
             try

--- a/Tests/Runtime/UNetTransportTest.cs
+++ b/Tests/Runtime/UNetTransportTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using Cysharp.Threading.Tasks;
 using Extreal.Core.Logging;
@@ -55,7 +56,7 @@ namespace Extreal.Integration.Multiplay.NGO.Test
         [UnityTest]
         public IEnumerator ConnectToServerSuccess() => UniTask.ToCoroutine(async () =>
         {
-            var ngoConfig = new NgoConfig(timeoutSeconds: 180);
+            var ngoConfig = new NgoConfig(timeout: TimeSpan.FromMinutes(3));
 
             Assert.IsFalse(onConnected);
             var result = await ngoClient.ConnectAsync(ngoConfig);


### PR DESCRIPTION
close #5 

# Describe Your Changes (なんの変更を加えましたか?)

- Changed timouout seconds from `byte` to `TimeSpan`. (タイムアウトの時間を `byte` から `TimeSpan` に変更した)

# What did you verify? (何を確認しましたか?)

- [x] Verified that processing for invalid arguments and invalid method calls is included (無効な引数や無効なメソッド呼び出しに対する処理が入っていることを確認しました)
- [x] Verified that debug logs are being output to show behavior at runtime (実行時の動作が分かるようなデバッグログを出力していることを確認しました)
- [x] Verified that no problems were found in the static analysis (静的解析で問題が見つからないことを確認しました)
- [x] Verified that all tests succeeded (全てのテストが成功することを確認しました)
- [x] Verified that test coverage is 100% (テストカバレッジが100%になることを確認しました)

# Message to reviewers (レビュアーへのメッセージ)

- [x] 気になる点はありませんか？

