### PR TITLE
NgoConfigのAddressプロパティにドメイン名を指定できるようにする

### DIFF
--- a/Runtime/NgoConfig.cs
+++ b/Runtime/NgoConfig.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net;
 
 namespace Extreal.Integration.Multiplay.NGO
 {
@@ -11,7 +10,7 @@ namespace Extreal.Integration.Multiplay.NGO
         /// <summary>
         /// Uses in connection.
         /// </summary>
-        /// <value>IP Address to be used in connection.</value>
+        /// <value>Address to be used in connection.</value>
         public string Address { get; internal set; }
 
         /// <summary>
@@ -35,14 +34,14 @@ namespace Extreal.Integration.Multiplay.NGO
         /// <summary>
         /// Creates a new NgoConfig with given address, port, connectionData and timeout.
         /// </summary>
-        /// <param name="address">IP Address to be used in connection.</param>
+        /// <param name="address">Address to be used in connection.</param>
         /// <param name="port">Port to be used in connection.</param>
         /// <param name="connectionData">Connection data to be used in connection.</param>
         /// <param name="timeout">
         /// <para>Time to wait when connection is not successful.</para>
         /// Default: 10 seconds
         /// </param>
-        /// <exception cref="ArgumentException">If the form of 'address' is invalid.</exception>
+        /// <exception cref="ArgumentNullException">If 'address' is null.</exception>
         public NgoConfig
         (
             string address = "127.0.0.1",
@@ -51,9 +50,9 @@ namespace Extreal.Integration.Multiplay.NGO
             TimeSpan timeout = default
         )
         {
-            if (!IPAddress.TryParse(address, out var _))
+            if (string.IsNullOrEmpty(address))
             {
-                throw new ArgumentException($"The form of '{nameof(address)}' is invalid");
+                throw new ArgumentNullException(nameof(address));
             }
 
             Address = address;

--- a/Tests/Runtime/NgoConfigTest.cs
+++ b/Tests/Runtime/NgoConfigTest.cs
@@ -6,9 +6,9 @@ namespace Extreal.Integration.Multiplay.NGO.Test
     public class NgoConfigTest
     {
         [Test]
-        public void NewNgoConfigWithInvalidIpAddressForm()
-            => Assert.That(() => _ = new NgoConfig("256:0:0:1"),
-                Throws.TypeOf<ArgumentException>()
-                    .With.Message.EqualTo("The form of 'address' is invalid"));
+        public void NewNgoConfigWithAddressNull()
+            => Assert.That(() => _ = new NgoConfig(null),
+                Throws.TypeOf<ArgumentNullException>()
+                    .With.Message.Contains("address"));
     }
 }


### PR DESCRIPTION
# 何の変更を加えましたか？

[Commits](https://github.com/extreal-dev/Extreal.Integration.Multiplay.NGO/pull/18/commits)を参照してください。

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [ ] ~全ての自動テストが成功することを確認しました~
- [ ] ~テストカバレッジが100%になることを確認しました~
- [ ] ~サンプルがあるものはサンプルが動作することを確認しました~

変更はNgoConfigのコンストラクタの引数チェックのみのため、対象のテストのみ実施、カバレッジが通ることを確認済み。

## 変更影響

- [x] GuideのReleaseページに変更内容が追加されることを確認しました
  - https://github.com/extreal-dev/Extreal.Guide/pull/45
- [ ] ~GuideのModuleページ（機能ページ）に変更が反映されることを確認しました~
- [ ] ~GuideのLearningページに変更が反映されることを確認しました~
- [ ] ~Sample Applicationに変更が反映されることを確認しました~

GuideのReleaseページ以外は変更影響がないことを確認済み。

# レビュアーへのメッセージ

- 気になることはありますか？
